### PR TITLE
Remove GitLab configuration on registry

### DIFF
--- a/registry/config.yml
+++ b/registry/config.yml
@@ -7,12 +7,6 @@ anonymous_browsing:
 oauth:
   local_login:
     enabled: true
-  gitlab:
-    enabled: true
-    application_id: <application_id>
-    secret: <secret>
-    group: "cs20-42"
-    server: "https://gitlab.utwente.nl"
 
 delete:
   enabled: true


### PR DESCRIPTION
This PR removes the GitLab configuration on Portus as it isn't necessary.