### PR TITLE
Change network names in Traefik config

### DIFF
--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: unless-stopped
     networks:
       - default
-      - nsadmin-api_default
+      - nsadmin_production_default
       - docker_registry_default
     ports:
       - 80:80
@@ -20,7 +20,7 @@ services:
       - ./dynamic:/dynamic/
 
 networks:
-  nsadmin-api_default:
+  nsadmin_production_default:
     external: true
   docker_registry_default:
     external: true


### PR DESCRIPTION
This PR changes the network names in the Traefik docker-compose.yml as I finally understand how to give the containers custom names.