### PR TITLE
fix: Postgres backups

### DIFF
--- a/postgres-backup/Dockerfile
+++ b/postgres-backup/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y wget gnupg2 curl
 
 # Add Postgres libraries
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update && apt-get install -y postgresql-client
 


### PR DESCRIPTION
This PR changes the used codename for installing the Postgres packages to the correct one (it used "trusty", codename for Ubuntu 14). This fixes the backups from not running.