### PR TITLE
fix(backups): include db name in location variable

### DIFF
--- a/postgres-backup/models/db_arora_api_backup.sh
+++ b/postgres-backup/models/db_arora_api_backup.sh
@@ -4,11 +4,11 @@ KEEP=30
 # String to append to the name of the backup files
 DATE=$(date +%Y.%m.%d.%H.%M.%S)
 
-echo "Dumping $1 to $BACKUP_LOCATION/$1/$DATE/$1.tar.enc"
+echo "Dumping $1 to $BACKUP_LOCATION/$DATE/$1.tar.enc"
 export PGPASSWORD=$POSTGRES_PASSWORD
-mkdir -p "$BACKUP_LOCATION"/"$1"/"$DATE"
+mkdir -p "$BACKUP_LOCATION"/"$DATE"
 pg_dump -Ft --username="$POSTGRES_USER" -h db "$POSTGRES_DATABASE" | gzip | \
-  openssl aes-256-cbc -base64 -md sha256 -pass file:password -salt -out "$BACKUP_LOCATION"/"$1"/"$DATE"/"$1".tar.enc
+  openssl aes-256-cbc -base64 -md sha256 -pass file:password -salt -out "$BACKUP_LOCATION"/"$DATE"/"$1".tar.enc
 
 find "$BACKUP_LOCATION" -mindepth 1 -maxdepth 1 -mtime +$KEEP -exec rm -rf {} +
 

--- a/postgres-backup/models/db_arora_discord_backup.sh
+++ b/postgres-backup/models/db_arora_discord_backup.sh
@@ -4,11 +4,11 @@ KEEP=30
 # String to append to the name of the backup files
 DATE=$(date +%Y.%m.%d.%H.%M.%S)
 
-echo "Dumping $1 to $BACKUP_LOCATION/$1/$DATE/$1.tar.enc"
+echo "Dumping $1 to $BACKUP_LOCATION/$DATE/$1.tar.enc"
 export PGPASSWORD=$POSTGRES_PASSWORD
-mkdir -p "$BACKUP_LOCATION"/"$1"/"$DATE"
+mkdir -p "$BACKUP_LOCATION"/"$DATE"
 pg_dump -Ft --username="$POSTGRES_USER" -h db "$POSTGRES_DATABASE" | gzip | \
-  openssl aes-256-cbc -base64 -md sha256 -pass file:password -salt -out "$BACKUP_LOCATION"/"$1"/"$DATE"/"$1".tar.enc
+  openssl aes-256-cbc -base64 -md sha256 -pass file:password -salt -out "$BACKUP_LOCATION"/"$DATE"/"$1".tar.enc
 
 find "$BACKUP_LOCATION" -mindepth 1 -maxdepth 1 -mtime +$KEEP -exec rm -rf {} +
 


### PR DESCRIPTION
Removes the db name from the paths, so these must now be specified in the backup location variable.