### PR TITLE
feat: add configurations for macvlan on IPv6

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -21,6 +21,7 @@ services:
 
 networks:
   a_macnet178:
+    enable_ipv6: true
     driver: macvlan
     driver_opts:
       parent: <interface>
@@ -29,3 +30,5 @@ networks:
         - subnet: 192.168.178.0/24
           gateway: 192.168.178.1
           ip_range: 192.168.178.100/27
+        - subnet: <ipv6/prefixlength>
+          gateway: <ipv6>

--- a/pihole/docker-compose.yml
+++ b/pihole/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       default:
       home_assistant_a_macnet178:
         ipv4_address: 192.168.178.101
+        ipv6_address: <ipv6>
 
 networks:
   home_assistant_a_macnet178:


### PR DESCRIPTION
Configures IPv6 for the macvlan Docker network so that Pi-hole's DNS server also gets an IP v6 address.