### PR TITLE
feat: disable backup notifiers call

### DIFF
--- a/postgres-backup/models/db_arora_api_backup.sh
+++ b/postgres-backup/models/db_arora_api_backup.sh
@@ -12,4 +12,4 @@ pg_dump -Ft --username="$POSTGRES_USER" -h db "$POSTGRES_DATABASE" | gzip | \
 
 find "$BACKUP_LOCATION" -mindepth 1 -maxdepth 1 -mtime +$KEEP -exec rm -rf {} +
 
-bash notifiers/discord.sh "$1"
+#bash notifiers/discord.sh "$1"

--- a/postgres-backup/models/db_arora_discord_backup.sh
+++ b/postgres-backup/models/db_arora_discord_backup.sh
@@ -12,4 +12,4 @@ pg_dump -Ft --username="$POSTGRES_USER" -h db "$POSTGRES_DATABASE" | gzip | \
 
 find "$BACKUP_LOCATION" -mindepth 1 -maxdepth 1 -mtime +$KEEP -exec rm -rf {} +
 
-bash notifiers/discord.sh "$1"
+#bash notifiers/discord.sh "$1"


### PR DESCRIPTION
Since the backups have been using Healtchecks.io for a while, these notifications are not necessary anymore and they kind of spam the channel.