### PR TITLE
feat(harbor): add systemctl service file

### DIFF
--- a/harbor/README.md
+++ b/harbor/README.md
@@ -1,0 +1,12 @@
+Harbor
+================
+
+Configuration files for Harbor.
+
+## Extra setup
+
+The files in this directory are the only files that were modified after running the Harbor install script. 
+
+1. Copy `harbor.service` to `/etc/systemd/system/harbor.service`.
+2. Start Harbor by running `sudo systemctl start harbor`.
+3. Enable Harbor by running `sudo systemctl enable harbor`.

--- a/harbor/docker-compose.yml
+++ b/harbor/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: goharbor/harbor-log:v2.2.1
     container_name: harbor-log
     restart: always
-    dns_search: .
     cap_drop:
       - ALL
     cap_add:
@@ -47,7 +46,6 @@ services:
         target: /harbor_cust_cert
     networks:
       - harbor
-    dns_search: .
     depends_on:
       - log
     logging:
@@ -79,7 +77,6 @@ services:
         target: /harbor_cust_cert
     networks:
       - harbor
-    dns_search: .
     depends_on:
       - log
     logging:
@@ -103,7 +100,6 @@ services:
       - /var/lib/docker/volumes/harbor_data/_data/database:/var/lib/postgresql/data:z
     networks:
       harbor:
-    dns_search: .
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -143,7 +139,6 @@ services:
         target: /harbor_cust_cert
     networks:
       harbor:
-    dns_search: .
     depends_on:
       - log
       - registry
@@ -172,7 +167,6 @@ services:
         target: /etc/nginx/nginx.conf
     networks:
       - harbor
-    dns_search: .
     depends_on:
       - log
     logging:
@@ -203,7 +197,6 @@ services:
         target: /harbor_cust_cert
     networks:
       - harbor
-    dns_search: .
     depends_on:
       - core
     logging:
@@ -226,7 +219,6 @@ services:
       - /var/lib/docker/volumes/harbor_data/_data/redis:/var/lib/redis
     networks:
       harbor:
-    dns_search: .
     depends_on:
       - log
     logging:
@@ -257,7 +249,6 @@ services:
         target: /harbor_cust_cert
     networks:
       - harbor
-    dns_search: .
 #     ports:
 #       - 80:8080
     depends_on:

--- a/harbor/harbor.service
+++ b/harbor/harbor.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Harbor Service
+After=network.target docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/docker/harbor
+ExecStart=/usr/local/bin/docker-compose -f /opt/docker/harbor/docker-compose.yml up
+ExecStop=/usr/local/bin/docker-compose -f /opt/docker/harbor/docker-compose.yml down
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Harbor breaks after a system reboot, this PR adds a systemctl service file for it so that it is started on system boot with correct permissions.

Also removed the `dns_search` directives as they were commented in the config on the server already and they were also deleted in Harbor's own repository.