### PR TITLE
feat: add Cloudflare DDNS configuration

### DIFF
--- a/cloudflare-ddns/.env.example
+++ b/cloudflare-ddns/.env.example
@@ -1,0 +1,2 @@
+API_KEY=<token>
+ZONE=<url>

--- a/cloudflare-ddns/docker-compose.yml
+++ b/cloudflare-ddns/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  cloudflare_ddns_ipv4: &default
+    image: oznu/cloudflare-ddns:amd64@sha256:f552b1053ca4bad934eb3ca16e2d22decefe4423e2bf3e0a354fa1ab03b46390
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      PROXIED: 'true'
+    network_mode: host
+
+  cloudflare_ddns_ipv6:
+    <<: *default
+    environment:
+      RRTYPE: AAAA
+      PROXIED: 'true'


### PR DESCRIPTION
Adds a configuration that starts 2 containers to update the Cloudflare A and AAAA DNS records.