### PR TITLE
revert: chore(deps): update helm release pihole to v2.31.0

### DIFF
--- a/pihole/Chart.lock
+++ b/pihole/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: pihole
-  repository: https://mojo2600.github.io/pihole-kubernetes
-  version: 2.31.0
-digest: sha256:171ec045b2120afa9346a889dfcbfb53be47ae4788aa7f8de1a68558825494ee
-generated: "2025-05-30T22:17:18.588948012Z"
+  repository: https://mojo2600.github.io/pihole-kubernetes/
+  version: 2.27.0
+digest: sha256:7900ea5a9928195963bdfcf331f6494ad87548568f01589336687b1875d90648
+generated: "2025-01-12T02:46:50.078774659+01:00"

--- a/pihole/Chart.yaml
+++ b/pihole/Chart.yaml
@@ -19,5 +19,5 @@ version: 0.1.0
 
 dependencies:
   - name: pihole
-    version: 2.31.0
+    version: 2.27.0
     repository: https://mojo2600.github.io/pihole-kubernetes


### PR DESCRIPTION
Reverts guidojw/maia#76, caused issues with machines not being on local network, probably a `dnsmasq.d` setting I'm missing. Have to dig more into the v6 migration.